### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/sanjaybajracharya4/d2c389e9-c8a3-41d8-8679-a28475b68761/63eb8508-17f8-4995-9bfa-f3361e700cfb/_apis/work/boardbadge/bd3db25a-c29c-440a-a4f1-27e8fd9cd95d)](https://dev.azure.com/sanjaybajracharya4/d2c389e9-c8a3-41d8-8679-a28475b68761/_boards/board/t/63eb8508-17f8-4995-9bfa-f3361e700cfb/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/sanjaybajracharya4/d2c389e9-c8a3-41d8-8679-a28475b68761/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.